### PR TITLE
Bump zed_extension_api for windows path fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ef88a8e5aeff67b0996b1795d56338f04c02de95f1f147577944aa37b801d6"
+checksum = "0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ path = "src/mcp_server_context7.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.5.0"
+zed_extension_api = "0.7.0"
 serde = "1.0"
 schemars = "0.8"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "mcp-server-context7"
 name = "Context7 MCP Server"
 description = "Model Context Protocol Server for Context7"
-version = "0.0.4"
+version = "0.0.5"
 schema_version = 1
 authors = ["Akbxr <hi@akbxr.com>"]
 repository = "https://github.com/akbxr/zed-mcp-server-context7"


### PR DESCRIPTION
Closes #1 

I've also bumped the extension version to 0.0.5, so that we can publish a new release.